### PR TITLE
Enable SigMaker for ELF binaries

### DIFF
--- a/SigMaker/Main.cpp
+++ b/SigMaker/Main.cpp
@@ -95,9 +95,6 @@ bool idaapi run( size_t /*arg*/ )
 
 int idaapi init( void )
 {
-    if (inf.filetype != f_PE)
-        return PLUGIN_SKIP;
-
     Settings.Init( );
     Settings.Load( "sigmaker.ini" );
 


### PR DESCRIPTION
It works just fine for ELF binaries.

Btw why are so many of the other file types also allowed? I can't come up with a reason why creating signatures wouldn't work for any filetype. As long as you can see what parts are variable and need to be masked out ofcause.