### PR TITLE
Refactored SearchForSigs to use omin_ea

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,25 @@
 # SigMaker-x64
 
-IDA SigMaker Plugin updated for the IDA Pro 7.0 SDK.
+IDA SigMaker Plugin updated for the IDA Pro 7.0 SDK by [dude719](https://github.com/dude719).
 
-PLEASE NOTE: IDA Freeware 7.0 is NOT supported. 
-
+PLEASE NOTE: IDA Freeware 7.0 is **NOT** supported. 
 
 Originally made by P4TR!CK
 
-Credits also go to bobbysing and xero|hawk
+Credits also go to bobbysing and [xero|hawk](https://github.com/XeroHawk)
 
-Thanks to gir489 for the contributions
+Thanks to [gir489](https://github.com/gir489) for the contributions
 
 RIP GameDeception
+
+# Installation
+
+Visual Studio will expect the environment variable IDADIR to resolve to your IDA 7.0 installation directory.
+
+Visual Studio will also expect the SDK to be located at %IDADIR%\idasdk. Make sure these folders resolve in Windows properly before attempting to build the project.
+
+# Running the build
+
+Because IDA no longer has a native 32-bit compiled version anymore, the Release/Debug is the build script for the 32-bit version of IDA and Release64/Debug64 is the build script for the 64-bit version. 
+
+**Do not change the target platform from x64!**

--- a/SigMaker/Converter.cpp
+++ b/SigMaker/Converter.cpp
@@ -165,7 +165,7 @@ void IDAToCRC( const qstring& strSig, ea_t& dwCRC32, ea_t& dwMask )
     {
         if (i <= iCount && szMask[i] == 'x')
         {
-            dwMask |= (1 << i);
+            dwMask |= (1i64 << i);
         }
         else
         {
@@ -186,7 +186,7 @@ void CodeToCRC( const qstring& strByteSig, const qstring& strMask, ea_t& dwCRC32
     {
         if (i <= iCount && szMask[i] == 'x')
         {
-            dwMask |= 1 << i;
+            dwMask |= 1i64 << i;
         }
         else
         {

--- a/SigMaker/Includes.h
+++ b/SigMaker/Includes.h
@@ -8,26 +8,9 @@
 #pragma warning( push )  
 #pragma warning( disable : 4267 )
 #pragma warning( disable : 4244 )
-#include <ida.hpp>
-#include <idp.hpp>
-#include <enum.hpp>
-#include <frame.hpp> 
 #include <expr.hpp>
-#include <name.hpp>
-#include <segment.hpp>
-#include <bytes.hpp>
-#include <struct.hpp>
 #include <loader.hpp>
-#include <kernwin.hpp>
-#include <auto.hpp>
-#include <entry.hpp>
-#include <bytes.hpp>
-#include <typeinf.hpp>
-#include <demangle.hpp>
-#include <allins.hpp>
 #include <search.hpp> // find_binary
-#include <ua.hpp>
-#include <fpro.h>
 #include <diskio.hpp>
 #pragma warning( pop ) 
 

--- a/SigMaker/Includes.h
+++ b/SigMaker/Includes.h
@@ -5,6 +5,9 @@
 #define __NT__                  1
 #define __X64__                 1
 
+#pragma warning( push )  
+#pragma warning( disable : 4267 )
+#pragma warning( disable : 4244 )
 #include <ida.hpp>
 #include <idp.hpp>
 #include <enum.hpp>
@@ -26,6 +29,7 @@
 #include <ua.hpp>
 #include <fpro.h>
 #include <diskio.hpp>
+#pragma warning( pop ) 
 
 #pragma comment(lib, "ida.lib")
 #pragma comment(lib, "pro.lib")

--- a/SigMaker/Search.cpp
+++ b/SigMaker/Search.cpp
@@ -14,72 +14,39 @@ int GetOccurenceCount( const qstring& strSig, bool bSkipOut = false )
     int iCount = 0;
     ea_t dwAddress = find_binary( inf.min_ea, inf.max_ea, strSig.c_str( ), 16, SEARCH_DOWN );
 
-    if (IsValidEA( dwAddress ))
-    {
-        do
-        {
-            if (bSkipOut == true && iCount >= 2)
-                return iCount;
-
-            iCount++;
-            dwAddress = find_binary( dwAddress + 1, inf.max_ea, strSig.c_str( ), 16, SEARCH_DOWN );
-        } while (IsValidEA( dwAddress ));
-    }
-    else
-    {
-        dwAddress = find_binary( inf.omin_ea, inf.omax_ea, strSig.c_str( ), 16, SEARCH_DOWN );
-        if (IsValidEA( dwAddress ))
-        {
-            do
-            {
-                if (bSkipOut == true && iCount >= 2)
-                    return iCount;
-                iCount++;
-                dwAddress = find_binary( dwAddress + 1, inf.omax_ea, strSig.c_str( ), 16, SEARCH_DOWN );
-            } while (IsValidEA( dwAddress ));
-        }
-    }
+	dwAddress = find_binary(inf.omin_ea, inf.omax_ea, strSig.c_str(), 16, SEARCH_DOWN);
+	if (IsValidEA(dwAddress))
+	{
+		do
+		{
+			if (bSkipOut == true && iCount >= 2)
+				return iCount;
+			iCount++;
+			dwAddress = find_binary(dwAddress + 1, inf.omax_ea, strSig.c_str(), 16, SEARCH_DOWN);
+		} while (IsValidEA(dwAddress));
+	}
 
     return iCount;
 }
 
 void SearchForSigs( const qstring& strSig )
 {
-    ea_t dwAddress = find_binary( inf.min_ea, inf.max_ea, strSig.c_str( ), 16, SEARCH_DOWN );
+    ea_t dwAddress = find_binary( inf.omin_ea, inf.omax_ea, strSig.c_str( ), 16, SEARCH_DOWN );
 
     const char* pszMessage = "===========================\n";
 
     msg( pszMessage );
 
-    if (IsValidEA( dwAddress ))
-    {
-        do
-        {
-#ifdef __EA64__
-			msg("sig found at 1%X\n", dwAddress);
-#else
-			msg("sig found at %X\n", dwAddress);
-#endif
-            dwAddress = find_binary( dwAddress + 1, inf.max_ea, strSig.c_str( ), 16, SEARCH_DOWN );
-        } while (IsValidEA( dwAddress ));
-    }
-    else
-    {
-        dwAddress = find_binary( inf.omin_ea, inf.omax_ea, strSig.c_str( ), 16, SEARCH_DOWN );
+	dwAddress = find_binary(inf.omin_ea, inf.omax_ea, strSig.c_str(), 16, SEARCH_DOWN);
 
-        if (IsValidEA( dwAddress ))
-        {
-            do
-            {
-#ifdef __EA64__
-                msg( "sig found at 1%X\n", dwAddress );
-#else
-				msg("sig found at %X\n", dwAddress);
-#endif
-                dwAddress = find_binary( dwAddress + 1, inf.omax_ea, strSig.c_str( ), 16, SEARCH_DOWN );
-            } while (IsValidEA( dwAddress ));
-        }
-    }
+	if (IsValidEA(dwAddress))
+	{
+		do
+		{
+			msg("sig found at %llX\n", dwAddress);
+			dwAddress = find_binary(dwAddress + 1, inf.omax_ea, strSig.c_str(), 16, SEARCH_DOWN);
+		} while (IsValidEA(dwAddress));
+	}
     msg( pszMessage );
 }
 

--- a/SigMaker/SigMaker.vcxproj
+++ b/SigMaker/SigMaker.vcxproj
@@ -22,7 +22,7 @@
     <ProjectGuid>{60916877-60AB-4565-93BC-2D6097976D86}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>SigMaker</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">


### PR DESCRIPTION
I discovered a regression issue when working with i64 databases dumped with [Scylla](https://github.com/NtQuery/Scylla). It resolves the relevative (original) address to whatever Windows had for the address of the module at the time it was dumped in the module. This was causing an issue with my bad 1+baseaddress hack that "worked."

However, after doing some digging in the code, I noticed that I could just remove this entirely, if the SearchForSigs function just used omin_ea and omax_ea instead. I don't see a reason not to use this.

I also tidied up the project some, and added a more helpful ReadMe for newcomers to the project.