### PR TITLE
Added failure scenario for AutoGenerate

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,6 @@ Visual Studio will also expect the SDK to be located at %IDADIR%\idasdk. Make su
 
 # Running the build
 
-Because IDA no longer has a native 32-bit compiled version anymore, the Release/Debug is the build script for the 32-bit version of IDA and Release64/Debug64 is the build script for the 64-bit version. 
+Because IDA no longer has a native 32-bit compiled version anymore, the Release/Debug scenarios are the build scripts for the 32-bit version of IDA and Release64/Debug64 are the build scripts for the 64-bit version.
 
 **Do not change the target platform from x64!**

--- a/SigMaker/Generate.cpp
+++ b/SigMaker/Generate.cpp
@@ -400,6 +400,11 @@ void GenerateSig( SigType eType )
             }
         }
     }
+    else
+    {
+        msg("Failed to automatically generate signature at %X\n", dwAddress);
+        return;
+    }
 
     qstring strSig = (*SigIterator).strSig, strTmp;
     char szMask[MAXSTR];


### PR DESCRIPTION
I ran into an issue where I (accidentally) clicked Auto create ida pattern, and it crashed IDA, causing my database to get corrupted. It seemed to only do it on the PE I was working on, but I don't see a reason to continue execution if AutoGenerate returns false...