### PR TITLE
Fixed signature iterator loop.

### DIFF
--- a/SigMaker/Generate.cpp
+++ b/SigMaker/Generate.cpp
@@ -227,7 +227,7 @@ bool AutoGenerate( qSigVector& refvecSig, ea_t dwAddress )
                     msg( "not enough candidates to proceed. aborting...\n" );
                     return false;
                 }
-                vecSig.erase( i );
+                vecSig.erase( i-- );
                 continue;
             }
             (*i).iOpCount++;


### PR DESCRIPTION
We must reduce the iterator because the call qvector::erase() shifts vector and causes skipping elements of iterator in the loop. This cause crashes in some situations.